### PR TITLE
Fix linter errors

### DIFF
--- a/x/audit/keeper/audit.go
+++ b/x/audit/keeper/audit.go
@@ -75,9 +75,9 @@ func (k Keeper) GetLastProtocolID(ctx sdk.Context) uint64 {
 	return sdk.BigEndianToUint64(bz)
 }
 
-func (k Keeper) SetLastProtocolID(ctx sdk.Context, ID uint64) {
+func (k Keeper) SetLastProtocolID(ctx sdk.Context, id uint64) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.KeyLastProtocolID, sdk.Uint64ToBigEndian(ID))
+	store.Set(types.KeyLastProtocolID, sdk.Uint64ToBigEndian(id))
 }
 
 func (k Keeper) setProtocol(ctx sdk.Context, protocol types.Protocol) error {
@@ -90,25 +90,33 @@ func (k Keeper) setProtocol(ctx sdk.Context, protocol types.Protocol) error {
 	return nil
 }
 
-func (k Keeper) AddAttackPoolByProtocolId(ctx sdk.Context, protocolID uint64, amount sdk.Int) error {
+func (k Keeper) AddAttackPoolByProtocolID(ctx sdk.Context, protocolID uint64, amount sdk.Int) error {
 	protocol, err := k.GetProtocolByID(ctx, protocolID)
 	if err != nil {
 		return err
 	}
 
 	protocol.AttackPool = protocol.AttackPool.Add(amount)
-	k.setProtocol(ctx, *protocol)
+	err = k.setProtocol(ctx, *protocol)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func (k Keeper) AddDefensePoolByProtocolId(ctx sdk.Context, protocolID uint64, amount sdk.Int) error {
+func (k Keeper) AddDefensePoolByProtocolID(ctx sdk.Context, protocolID uint64, amount sdk.Int) error {
 	protocol, err := k.GetProtocolByID(ctx, protocolID)
 	if err != nil {
 		return err
 	}
 
 	protocol.DefensePool = protocol.DefensePool.Add(amount)
-	k.setProtocol(ctx, *protocol)
+	err = k.setProtocol(ctx, *protocol)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -125,7 +133,12 @@ func (k Keeper) AddErrata(ctx sdk.Context, protocolID uint64, vulnerabilityType 
 	}
 
 	protocol.Errata = append(protocol.Errata, &errata)
-	k.setProtocol(ctx, *protocol)
+	err = k.setProtocol(ctx, *protocol)
+
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/x/audit/keeper/msg_server.go
+++ b/x/audit/keeper/msg_server.go
@@ -34,7 +34,7 @@ func (k msgServer) RegisterProtocol(goCtx context.Context, msg *types.MsgRegiste
 func (k msgServer) JoinAttackPool(goCtx context.Context, msg *types.MsgJoinAttackPool) (*types.MsgJoinAttackPoolResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	err := k.keeper.AddAttackPoolByProtocolId(ctx, msg.PoolId, msg.TokenIn)
+	err := k.keeper.AddAttackPoolByProtocolID(ctx, msg.PoolId, msg.TokenIn)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (k msgServer) JoinAttackPool(goCtx context.Context, msg *types.MsgJoinAttac
 func (k msgServer) JoinDefensePool(goCtx context.Context, msg *types.MsgJoinDefensePool) (*types.MsgJoinDefensePoolResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	err := k.keeper.AddDefensePoolByProtocolId(ctx, msg.PoolId, msg.TokenIn)
+	err := k.keeper.AddDefensePoolByProtocolID(ctx, msg.PoolId, msg.TokenIn)
 	if err != nil {
 		return nil, err
 	}

--- a/x/audit/keeper/query.go
+++ b/x/audit/keeper/query.go
@@ -16,10 +16,8 @@ func NewQuerier(k Keeper, legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {
 			err error
 		)
 
-		switch path[0] {
-		default:
-			err = sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
-		}
+		// FIXME Should we implement querier?
+		err = sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
 
 		return res, err
 	}

--- a/x/audit/types/key.go
+++ b/x/audit/types/key.go
@@ -30,8 +30,8 @@ var (
 	KeyIndexSeparator = []byte{0xFF}
 )
 
-func ProtocolStoreKey(ID uint64) []byte {
-	return combineKeys(KeyProtocol, sdk.Uint64ToBigEndian(ID))
+func ProtocolStoreKey(id uint64) []byte {
+	return combineKeys(KeyProtocol, sdk.Uint64ToBigEndian(id))
 }
 
 // combineKeys combine bytes array into a single bytes

--- a/x/audit/types/msgs.go
+++ b/x/audit/types/msgs.go
@@ -56,9 +56,9 @@ func (msg MsgRegisterProtocol) ValidateBasic() error {
 	return nil
 }
 
-func NewMsgJoinAttackPool(poolId uint64, tokenIn sdk.Int) *MsgJoinAttackPool {
+func NewMsgJoinAttackPool(poolID uint64, tokenIn sdk.Int) *MsgJoinAttackPool {
 	return &MsgJoinAttackPool{
-		PoolId:  poolId,
+		PoolId:  poolID,
 		TokenIn: tokenIn,
 	}
 }
@@ -91,9 +91,9 @@ func (msg MsgJoinAttackPool) ValidateBasic() error {
 	return nil
 }
 
-func NewMsgJoinDefensePool(poolId uint64, tokenIn sdk.Int) *MsgJoinAttackPool {
+func NewMsgJoinDefensePool(poolID uint64, tokenIn sdk.Int) *MsgJoinAttackPool {
 	return &MsgJoinAttackPool{
-		PoolId:  poolId,
+		PoolId:  poolID,
 		TokenIn: tokenIn,
 	}
 }
@@ -126,9 +126,9 @@ func (msg MsgJoinDefensePool) ValidateBasic() error {
 	return nil
 }
 
-func NewMsgAddErrata(poolId uint64, vulnerabilityType string, errataCode string, vulnerability string) *MsgAddErrata {
+func NewMsgAddErrata(poolID uint64, vulnerabilityType string, errataCode string, vulnerability string) *MsgAddErrata {
 	return &MsgAddErrata{
-		PoolId:            poolId,
+		PoolId:            poolID,
 		VulnerabilityType: vulnerabilityType,
 		ErrataCode:        errataCode,
 		Vulnerability:     vulnerability,


### PR DESCRIPTION
This PR fixes some lint errors as below.

```
x/audit/keeper/audit.go:100:15: Error return value of `k.setProtocol` is not checked (errcheck)
        k.setProtocol(ctx, *protocol)
                     ^
x/audit/keeper/audit.go:111:15: Error return value of `k.setProtocol` is not checked (errcheck)
        k.setProtocol(ctx, *protocol)
                     ^
x/audit/keeper/audit.go:128:15: Error return value of `k.setProtocol` is not checked (errcheck)
        k.setProtocol(ctx, *protocol)
                     ^
x/audit/keeper/audit.go:78:52: captLocal: `ID' should not be capitalized (gocritic)
func (k Keeper) SetLastProtocolID(ctx sdk.Context, ID uint64) {
                                                   ^
x/audit/keeper/query.go:19:3: singleCaseSwitch: found switch with default case only (gocritic)
                switch path[0] {
                ^
x/audit/keeper/audit.go:93:17: method AddAttackPoolByProtocolId should be AddAttackPoolByProtocolID (golint)
func (k Keeper) AddAttackPoolByProtocolId(ctx sdk.Context, protocolID uint64, amount sdk.Int) error {
                ^
x/audit/keeper/audit.go:104:17: method AddDefensePoolByProtocolId should be AddDefensePoolByProtocolID (golint)
func (k Keeper) AddDefensePoolByProtocolId(ctx sdk.Context, protocolID uint64, amount sdk.Int) error {
                ^
x/audit/types/key.go:33:23: captLocal: `ID' should not be capitalized (gocritic)
func ProtocolStoreKey(ID uint64) []byte {
                      ^
x/audit/types/msgs.go:59:27: func parameter `poolId` should be `poolID` (golint)
func NewMsgJoinAttackPool(poolId uint64, tokenIn sdk.Int) *MsgJoinAttackPool {
                          ^
x/audit/types/msgs.go:94:28: func parameter `poolId` should be `poolID` (golint)
func NewMsgJoinDefensePool(poolId uint64, tokenIn sdk.Int) *MsgJoinAttackPool {
                           ^
x/audit/types/msgs.go:129:22: func parameter `poolId` should be `poolID` (golint)
func NewMsgAddErrata(poolId uint64, vulnerabilityType string, errataCode string, vulnerability string) *MsgAddErrata {
                     ^
```